### PR TITLE
[SNZ] update publish action to only run on main

### DIFF
--- a/.github/workflows/publish-snz.yml
+++ b/.github/workflows/publish-snz.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - 'main'
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch: # Manual trigger
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Prevent action from publishing "real" npm versions as beta versions from branches that aren't main
