### PR TITLE
Save multiple documents

### DIFF
--- a/packages/tinacms/src/toolkit/forms/dirty-forms.ts
+++ b/packages/tinacms/src/toolkit/forms/dirty-forms.ts
@@ -1,0 +1,1 @@
+export * from '../streamliners/dirty-forms';

--- a/packages/tinacms/src/toolkit/forms/index.ts
+++ b/packages/tinacms/src/toolkit/forms/index.ts
@@ -1,4 +1,5 @@
 export * from './form';
 export * from './field';
+export * from './dirty-forms';
 export type { ContentCreatorPlugin } from './content-creator-plugin';
 export type { FormApi } from 'final-form';

--- a/packages/tinacms/src/toolkit/streamliners/dirty-forms/components/dirty-form-sync.tsx
+++ b/packages/tinacms/src/toolkit/streamliners/dirty-forms/components/dirty-form-sync.tsx
@@ -1,0 +1,22 @@
+import type { FC } from 'react';
+import { useEffect } from 'react';
+import type { Form } from '../../../forms';
+import { dirtyFormStore } from '../utils/store';
+
+export const DirtyFormSync: FC<{ form: Form; pristine: boolean }> = ({
+  form,
+  pristine,
+}) => {
+  useEffect(() => {
+    if (pristine) {
+      dirtyFormStore.markClean(form.id);
+      return;
+    }
+    const dirtyFields = Object.keys(
+      form.finalForm.getState().dirtyFields || {}
+    );
+    dirtyFormStore.markDirty(form, dirtyFields);
+  }, [form, pristine]);
+
+  return null;
+};

--- a/packages/tinacms/src/toolkit/streamliners/dirty-forms/components/dirty-forms-modal.tsx
+++ b/packages/tinacms/src/toolkit/streamliners/dirty-forms/components/dirty-forms-modal.tsx
@@ -1,0 +1,50 @@
+import React, { type FC } from 'react';
+import {
+  Modal,
+  ModalActions,
+  ModalBody,
+  ModalHeader,
+  PopupModal,
+} from '../../../react-modals';
+import { Button } from '../../../styles';
+import type { DirtyFormEntry } from '../utils/store';
+
+const getEntryTitle = (entry: DirtyFormEntry) => {
+  const values = entry.form.values as any;
+  return values?.title || values?.name || entry.label || 'Document';
+};
+
+export const DirtyFormsModal: FC<{
+  open: boolean;
+  entries: DirtyFormEntry[];
+  onClose: () => void;
+}> = ({ open, entries, onClose }) => {
+  if (!open) return null;
+
+  return (
+    <Modal>
+      <PopupModal>
+        <ModalHeader>Files to be saved</ModalHeader>
+        <ModalBody padded={true}>
+          {entries.length === 0 ? (
+            <p className='text-gray-600 text-sm'>No dirty documents.</p>
+          ) : (
+            <ul className='text-sm text-gray-800 list-disc pl-5 space-y-1'>
+              {entries.map((entry) => (
+                <li key={entry.id}>
+                  <span className='font-medium'>{getEntryTitle(entry)}</span>
+                  <span className='text-gray-500'> — {entry.path}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </ModalBody>
+        <ModalActions>
+          <Button variant='secondary' onClick={onClose}>
+            Close
+          </Button>
+        </ModalActions>
+      </PopupModal>
+    </Modal>
+  );
+};

--- a/packages/tinacms/src/toolkit/streamliners/dirty-forms/hooks/use-dirty-form-count.ts
+++ b/packages/tinacms/src/toolkit/streamliners/dirty-forms/hooks/use-dirty-form-count.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+import { dirtyFormStore } from '../utils/store';
+
+export const useDirtyFormCount = () => {
+  const [count, setCount] = useState(dirtyFormStore.getDirtyForms().length);
+
+  useEffect(() => {
+    const updateCount = () =>
+      setCount(dirtyFormStore.getDirtyForms().length);
+    updateCount();
+    const unsubscribe = dirtyFormStore.subscribe(updateCount);
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  return count;
+};

--- a/packages/tinacms/src/toolkit/streamliners/dirty-forms/index.ts
+++ b/packages/tinacms/src/toolkit/streamliners/dirty-forms/index.ts
@@ -1,0 +1,7 @@
+export { DirtyFormSync } from './components/dirty-form-sync';
+export { DirtyFormsModal } from './components/dirty-forms-modal';
+export { useDirtyFormCount } from './hooks/use-dirty-form-count';
+export { attachDirtyFormTracking } from './utils/attach-dirty-form-tracking';
+export { dirtyFormStore } from './utils/store';
+export type { DirtyFormEntry } from './utils/store';
+export { submitOtherDirtyForms } from './utils/submit-other-dirty-forms';

--- a/packages/tinacms/src/toolkit/streamliners/dirty-forms/index.ts
+++ b/packages/tinacms/src/toolkit/streamliners/dirty-forms/index.ts
@@ -3,5 +3,5 @@ export { DirtyFormsModal } from './components/dirty-forms-modal';
 export { useDirtyFormCount } from './hooks/use-dirty-form-count';
 export { attachDirtyFormTracking } from './utils/attach-dirty-form-tracking';
 export { dirtyFormStore } from './utils/store';
-export type { DirtyFormEntry } from './utils/store';
+export type { DirtyFormEntry, DirtyFormStorePublic } from './utils/store';
 export { submitOtherDirtyForms } from './utils/submit-other-dirty-forms';

--- a/packages/tinacms/src/toolkit/streamliners/dirty-forms/utils/attach-dirty-form-tracking.ts
+++ b/packages/tinacms/src/toolkit/streamliners/dirty-forms/utils/attach-dirty-form-tracking.ts
@@ -1,0 +1,12 @@
+import type { Form } from '../../../forms';
+import { dirtyFormStore } from './store';
+
+export const attachDirtyFormTracking = (form: Form) => {
+  form.finalForm.subscribe(
+    ({ dirty, dirtyFields }) => {
+      if (!dirty) return;
+      dirtyFormStore.markDirty(form, Object.keys(dirtyFields || {}));
+    },
+    { dirty: true, dirtyFields: true }
+  );
+};

--- a/packages/tinacms/src/toolkit/streamliners/dirty-forms/utils/store.ts
+++ b/packages/tinacms/src/toolkit/streamliners/dirty-forms/utils/store.ts
@@ -1,4 +1,4 @@
-import type { Form } from '../../forms';
+import type { Form } from '../../../forms';
 
 export type DirtyFormEntry = {
   id: Form['id'];

--- a/packages/tinacms/src/toolkit/streamliners/dirty-forms/utils/store.ts
+++ b/packages/tinacms/src/toolkit/streamliners/dirty-forms/utils/store.ts
@@ -1,0 +1,58 @@
+import type { Form } from '../../forms';
+
+export type DirtyFormEntry = {
+  id: Form['id'];
+  path: string;
+  label: string;
+  form: Form;
+  dirtyFields?: string[];
+  updatedAt: number;
+};
+
+type Subscriber = () => void;
+
+class DirtyFormStore {
+  private dirtyForms = new Map<Form['id'], DirtyFormEntry>();
+  private subscribers = new Set<Subscriber>();
+
+  markDirty(form: Form, dirtyFields?: string[]) {
+    this.dirtyForms.set(form.id, {
+      id: form.id,
+      path: form.path,
+      label: form.label,
+      form,
+      dirtyFields,
+      updatedAt: Date.now(),
+    });
+    this.emit();
+  }
+
+  markClean(formId: Form['id']) {
+    if (this.dirtyForms.delete(formId)) {
+      this.emit();
+    }
+  }
+
+  isDirty(formId: Form['id']) {
+    return this.dirtyForms.has(formId);
+  }
+
+  getDirtyForms() {
+    return Array.from(this.dirtyForms.values());
+  }
+
+  getDirtyFormIds() {
+    return Array.from(this.dirtyForms.keys());
+  }
+
+  subscribe(callback: Subscriber) {
+    this.subscribers.add(callback);
+    return () => this.subscribers.delete(callback);
+  }
+
+  private emit() {
+    this.subscribers.forEach((callback) => callback());
+  }
+}
+
+export const dirtyFormStore = new DirtyFormStore();

--- a/packages/tinacms/src/toolkit/streamliners/dirty-forms/utils/store.ts
+++ b/packages/tinacms/src/toolkit/streamliners/dirty-forms/utils/store.ts
@@ -56,3 +56,14 @@ class DirtyFormStore {
 }
 
 export const dirtyFormStore = new DirtyFormStore();
+
+// Expose a public-only surface for TS consumers to avoid leaking private members.
+export type DirtyFormStorePublic = Pick<
+  DirtyFormStore,
+  | 'markDirty'
+  | 'markClean'
+  | 'isDirty'
+  | 'getDirtyForms'
+  | 'getDirtyFormIds'
+  | 'subscribe'
+>;

--- a/packages/tinacms/src/toolkit/streamliners/dirty-forms/utils/submit-other-dirty-forms.ts
+++ b/packages/tinacms/src/toolkit/streamliners/dirty-forms/utils/submit-other-dirty-forms.ts
@@ -1,0 +1,20 @@
+import type { Form } from '../../../forms';
+import { dirtyFormStore } from './store';
+
+export const submitOtherDirtyForms = async (activeForm: Form) => {
+  const dirtyEntries = dirtyFormStore
+    .getDirtyForms()
+    .filter((entry) => entry.id !== activeForm.id);
+  if (!dirtyEntries.length) {
+    return;
+  }
+  for (const entry of dirtyEntries) {
+    if (entry.form.submitting) {
+      continue;
+    }
+    if (!entry.form.valid) {
+      continue;
+    }
+    await entry.form.submit();
+  }
+};

--- a/packages/tinacms/src/toolkit/tina-cms.ts
+++ b/packages/tinacms/src/toolkit/tina-cms.ts
@@ -29,7 +29,7 @@ import {
 } from '@toolkit/fields';
 import type { FieldPlugin } from '@toolkit/form-builder';
 import type { Form } from '@toolkit/forms';
-import { dirtyFormStore } from '@toolkit/forms';
+import { dirtyFormStore, type DirtyFormStorePublic } from '@toolkit/forms';
 import {
   HtmlFieldPlaceholder,
   MarkdownFieldPlaceholder,
@@ -80,7 +80,7 @@ export class TinaCMS extends CMS {
   _alerts?: Alerts;
   state: TinaState;
   dispatch: React.Dispatch<TinaAction>;
-  dirtyForms = dirtyFormStore;
+  dirtyForms: DirtyFormStorePublic = dirtyFormStore;
   // We always attach the tina client to the cms instance
   api: { [key: string]: any; tina?: Client } = {};
 

--- a/packages/tinacms/src/toolkit/tina-cms.ts
+++ b/packages/tinacms/src/toolkit/tina-cms.ts
@@ -29,6 +29,7 @@ import {
 } from '@toolkit/fields';
 import type { FieldPlugin } from '@toolkit/form-builder';
 import type { Form } from '@toolkit/forms';
+import { dirtyFormStore } from '@toolkit/forms';
 import {
   HtmlFieldPlaceholder,
   MarkdownFieldPlaceholder,
@@ -79,6 +80,7 @@ export class TinaCMS extends CMS {
   _alerts?: Alerts;
   state: TinaState;
   dispatch: React.Dispatch<TinaAction>;
+  dirtyForms = dirtyFormStore;
   // We always attach the tina client to the cms instance
   api: { [key: string]: any; tina?: Client } = {};
 


### PR DESCRIPTION
This PR adds: 
- Track which forms are edited by the user
  - When the "save" button is pressed, loop through the forms and use the existing tinacms logic to save each form 
- Retain the ability to reset individual forms 
- Allow users to see a list of files that will be saved   

Note - Each document will still be saved as a seperate commit. 

Works in a single document 

https://github.com/user-attachments/assets/50536b5e-9d96-41b2-9fe0-5cfe68efde06



And across zones


https://github.com/user-attachments/assets/1009cf61-cd0b-46ac-810c-d1fe6e5789d5


